### PR TITLE
Implement shared types and centralized error model (T03)

### DIFF
--- a/src/config/service.ts
+++ b/src/config/service.ts
@@ -1,17 +1,24 @@
-import { getAppPaths, type AppPaths } from "./paths.js";
+import { appErrorCodes, toAppError } from "../shared/errors.js";
 import { readJson5File, writeJson5File } from "./file-store.js";
+import { getAppPaths, type AppPaths } from "./paths.js";
 import { appConfigSchema, getDefaultConfig, type AppConfig } from "./schema.js";
 
 export class ConfigService {
   constructor(private readonly paths: AppPaths = getAppPaths()) {}
 
   async load(): Promise<AppConfig> {
-    const config = await readJson5File(this.paths.configFile, getDefaultConfig());
-    return appConfigSchema.parse(config);
+    try {
+      const config = await readJson5File(this.paths.configFile, getDefaultConfig());
+      return appConfigSchema.parse(config);
+    } catch (error) {
+      throw toAppError(error, {
+        message: "Invalid configuration file",
+        code: appErrorCodes.configInvalid
+      });
+    }
   }
 
   async save(config: AppConfig): Promise<void> {
     await writeJson5File(this.paths.configFile, config);
   }
 }
-

--- a/src/ipc/client.ts
+++ b/src/ipc/client.ts
@@ -1,11 +1,20 @@
+import { appErrorCodes, toAppError } from "../shared/errors.js";
+import type { AppStatus } from "../shared/types.js";
+import { statusResponseSchema } from "./schema.js";
 import { IpcServer } from "./server.js";
-import type { StatusResponse } from "./schema.js";
 
 export class IpcClient {
   constructor(private readonly server = new IpcServer()) {}
 
-  getStatus(): Promise<StatusResponse> {
-    return this.server.getStatus();
+  async getStatus(): Promise<AppStatus> {
+    try {
+      const result = await this.server.getStatus();
+      return statusResponseSchema.parse(result);
+    } catch (error) {
+      throw toAppError(error, {
+        message: "Invalid IPC status response",
+        code: appErrorCodes.ipcInvalidResponse
+      });
+    }
   }
 }
-

--- a/src/ipc/schema.ts
+++ b/src/ipc/schema.ts
@@ -7,4 +7,3 @@ export const statusResponseSchema = z.object({
 });
 
 export type StatusResponse = z.infer<typeof statusResponseSchema>;
-

--- a/src/ipc/server.ts
+++ b/src/ipc/server.ts
@@ -1,7 +1,7 @@
-import type { StatusResponse } from "./schema.js";
+import type { AppStatus } from "../shared/types.js";
 
 export class IpcServer {
-  async getStatus(): Promise<StatusResponse> {
+  async getStatus(): Promise<AppStatus> {
     return {
       ok: true,
       service: "baliclaw",
@@ -9,4 +9,3 @@ export class IpcServer {
     };
   }
 }
-

--- a/src/runtime/agent-service.ts
+++ b/src/runtime/agent-service.ts
@@ -1,14 +1,21 @@
+import { appErrorCodes, toAppError } from "../shared/errors.js";
 import type { InboundMessage } from "../shared/types.js";
 import { buildTelegramDirectSessionId } from "../session/stable-key.js";
 import { queryAgent } from "./sdk.js";
 
 export class AgentService {
   async handleMessage(message: InboundMessage, cwd: string): Promise<string> {
-    return queryAgent({
-      prompt: message.text,
-      sessionId: buildTelegramDirectSessionId(message),
-      cwd
-    });
+    try {
+      return await queryAgent({
+        prompt: message.text,
+        sessionId: buildTelegramDirectSessionId(message),
+        cwd
+      });
+    } catch (error) {
+      throw toAppError(error, {
+        message: "Failed to query runtime agent",
+        code: appErrorCodes.runtimeAgentFailed
+      });
+    }
   }
 }
-

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -1,7 +1,16 @@
+export const appErrorCodes = {
+  ipcUnavailable: "IPC_UNAVAILABLE",
+  ipcInvalidResponse: "IPC_INVALID_RESPONSE",
+  configInvalid: "CONFIG_INVALID",
+  runtimeAgentFailed: "RUNTIME_AGENT_FAILED"
+} as const;
+
+export type AppErrorCode = (typeof appErrorCodes)[keyof typeof appErrorCodes];
+
 export class AppError extends Error {
   constructor(
     message: string,
-    readonly code: string,
+    readonly code: AppErrorCode,
     readonly cause?: unknown
   ) {
     super(message);
@@ -9,3 +18,13 @@ export class AppError extends Error {
   }
 }
 
+export function toAppError(
+  error: unknown,
+  defaults: { message: string; code: AppErrorCode }
+): AppError {
+  if (error instanceof AppError) {
+    return error;
+  }
+
+  return new AppError(defaults.message, defaults.code, error);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,11 +1,11 @@
 export type Channel = "telegram";
 export type AccountId = "default";
-export type ChatType = "direct" | "group" | "channel";
+export type ChatType = "direct";
 
 export interface InboundMessage {
   channel: Channel;
   accountId: AccountId;
-  chatType: "direct";
+  chatType: ChatType;
   conversationId: string;
   senderId: string;
   text: string;
@@ -14,16 +14,16 @@ export interface InboundMessage {
 export interface DeliveryTarget {
   channel: Channel;
   accountId: AccountId;
-  chatType: "direct";
+  chatType: ChatType;
   conversationId: string;
 }
 
 export interface PairingRequest {
-  channel: Channel;
-  accountId: AccountId;
-  senderId: string;
   code: string;
-  requestedAt: string;
+  senderId: string;
+  username?: string;
+  createdAt: string;
+  expiresAt: string;
 }
 
 export interface AppStatus {
@@ -31,4 +31,3 @@ export interface AppStatus {
   service: "baliclaw";
   version: string;
 }
-

--- a/test/ipc-client.test.ts
+++ b/test/ipc-client.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { IpcClient } from "../src/ipc/client.js";
+import { AppError, appErrorCodes } from "../src/shared/errors.js";
+
+describe("IpcClient", () => {
+  it("returns a shared AppStatus payload for valid responses", async () => {
+    const client = new IpcClient({
+      async getStatus() {
+        return { ok: true, service: "baliclaw", version: "test" };
+      }
+    });
+
+    await expect(client.getStatus()).resolves.toEqual({
+      ok: true,
+      service: "baliclaw",
+      version: "test"
+    });
+  });
+
+  it("throws AppError with centralized code for invalid responses", async () => {
+    const client = new IpcClient({
+      async getStatus() {
+        return { ok: true, service: "other", version: "test" } as unknown as { ok: true; service: "baliclaw"; version: string };
+      }
+    });
+
+    await expect(client.getStatus()).rejects.toMatchObject<AppError>({
+      name: "AppError",
+      code: appErrorCodes.ipcInvalidResponse
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a single, Phase‑1 aligned runtime type surface to avoid duplicated definitions and mismatches between IPC, runtime and transport layers.
- Centralize error codes and an error-wrapping helper to ensure structured IPC/runtime errors instead of scattered raw strings.
- Make IPC responses validated against a shared schema so invalid/malformed IPC payloads surface via the centralized error model.

### Description
- Add and tighten shared runtime types in `src/shared/types.ts` to match the tech spec (Phase 1 `ChatType` is `direct`, canonical `InboundMessage`, `DeliveryTarget`, `PairingRequest`, and `AppStatus`).
- Introduce centralized error model in `src/shared/errors.ts` with `appErrorCodes`, typed `AppError`, and `toAppError` helper for consistent error wrapping.
- Wire shared errors into core services: `ConfigService.load()` now wraps parse/load failures with `toAppError`, and `AgentService.handleMessage()` wraps `queryAgent` failures with a structured error code.
- Make IPC client/server use the shared types and schema validation: `IpcServer.getStatus()` returns the shared `AppStatus`, while `IpcClient.getStatus()` validates the response with `statusResponseSchema` and throws a centralized `AppError` on invalid responses.
- Add unit tests `test/ipc-client.test.ts` to assert valid status passthrough and that invalid IPC responses produce a centralized `AppError` with the expected code.

### Testing
- Ran the unit test suite with `pnpm test`, which completed successfully (3 test files, 4 tests passed).
- Built the project with `pnpm build`, which succeeded without TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b13dd67260832ab9fe874264f47b86)