### PR TITLE
Implement T04: state path and directory management

### DIFF
--- a/src/auth/pairing-store.ts
+++ b/src/auth/pairing-store.ts
@@ -6,7 +6,7 @@ export interface PairingStoreData {
 }
 
 export class PairingStore {
-  private readonly file = getAppPaths().pairingStoreFile;
+  private readonly file = getAppPaths().allowlistFile;
 
   async load(): Promise<PairingStoreData> {
     return readJson5File<PairingStoreData>(this.file, { approvedSenderIds: [] });

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,3 +1,4 @@
+import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -5,18 +6,34 @@ export interface AppPaths {
   rootDir: string;
   configFile: string;
   socketFile: string;
-  pairingStoreFile: string;
+  pairingDir: string;
+  pendingPairingFile: string;
+  allowlistFile: string;
+  logsDir: string;
   logFile: string;
 }
 
 export function getAppPaths(home = homedir()): AppPaths {
   const rootDir = join(home, ".baliclaw");
+  const pairingDir = join(rootDir, "pairing");
+  const logsDir = join(rootDir, "logs");
+
   return {
     rootDir,
-    configFile: join(rootDir, "config.json5"),
+    configFile: join(rootDir, "baliclaw.json5"),
     socketFile: join(rootDir, "baliclaw.sock"),
-    pairingStoreFile: join(rootDir, "pairing-store.json"),
-    logFile: join(rootDir, "baliclaw.log")
+    pairingDir,
+    pendingPairingFile: join(pairingDir, "telegram-pending.json"),
+    allowlistFile: join(pairingDir, "telegram-allowlist.json"),
+    logsDir,
+    logFile: join(logsDir, "daemon.log")
   };
 }
 
+export async function ensureStateDirectories(paths: AppPaths = getAppPaths()): Promise<void> {
+  await Promise.all([
+    mkdir(paths.rootDir, { recursive: true }),
+    mkdir(paths.pairingDir, { recursive: true }),
+    mkdir(paths.logsDir, { recursive: true })
+  ]);
+}

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,11 +1,37 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { getAppPaths } from "../src/config/paths.js";
+import { ensureStateDirectories, getAppPaths } from "../src/config/paths.js";
 
 describe("getAppPaths", () => {
   it("derives the managed state files under ~/.baliclaw", () => {
     const paths = getAppPaths("/tmp/example-home");
     expect(paths.rootDir).toBe("/tmp/example-home/.baliclaw");
-    expect(paths.configFile).toBe("/tmp/example-home/.baliclaw/config.json5");
+    expect(paths.configFile).toBe("/tmp/example-home/.baliclaw/baliclaw.json5");
     expect(paths.socketFile).toBe("/tmp/example-home/.baliclaw/baliclaw.sock");
+    expect(paths.pendingPairingFile).toBe("/tmp/example-home/.baliclaw/pairing/telegram-pending.json");
+    expect(paths.allowlistFile).toBe("/tmp/example-home/.baliclaw/pairing/telegram-allowlist.json");
+    expect(paths.logFile).toBe("/tmp/example-home/.baliclaw/logs/daemon.log");
+  });
+});
+
+describe("ensureStateDirectories", () => {
+  it("creates root, pairing, and logs directories", async () => {
+    const home = await mkdtemp(join(tmpdir(), "baliclaw-home-"));
+    try {
+      const paths = getAppPaths(home);
+      await ensureStateDirectories(paths);
+
+      const stateDir = await stat(paths.rootDir);
+      const pairingDir = await stat(paths.pairingDir);
+      const logsDir = await stat(paths.logsDir);
+
+      expect(stateDir.isDirectory()).toBe(true);
+      expect(pairingDir.isDirectory()).toBe(true);
+      expect(logsDir.isDirectory()).toBe(true);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
### Motivation
- Align state path handling with the Phase 1 tech spec by centralizing the `~/.baliclaw` layout and avoiding hardcoded paths scattered across modules.
- Ensure the daemon and CLI have a single source of truth for config, socket, pairing, and logs paths so future modules can rely on consistent locations.
- Provide a safe way to create required state directories at startup to avoid race conditions and duplicated directory creation logic.

### Description
- Replaced the previous `paths` implementation with `src/config/paths.ts` that returns an `AppPaths` object including `rootDir`, `configFile`, `socketFile`, `pairingDir`, `pendingPairingFile`, `allowlistFile`, `logsDir`, and `logFile` and renamed the config file to `baliclaw.json5`.
- Added `ensureStateDirectories(paths?)` in `src/config/paths.ts` which creates the `root`, `pairing`, and `logs` directories using `mkdir(..., { recursive: true })`.
- Updated pairing persistence in `src/auth/pairing-store.ts` to write to the new allowlist path (`pairing/telegram-allowlist.json`).
- Extended `test/paths.test.ts` to validate full path derivation and to test that `ensureStateDirectories` creates the required directories.

### Testing
- Ran `pnpm test` and the Vitest suite succeeded with all tests passing (`Test Files 3 passed`, `Tests 5 passed`).
- Ran `pnpm build` and TypeScript compilation (`tsc`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1417808c0832a80417d714df1256b)