### PR TITLE
Implement Telegram message normalization (T13)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: latest
+        specifier: 0.2.72
         version: 0.2.72(zod@4.3.6)
       chokidar:
         specifier: ^4.0.3

--- a/src/telegram/normalize.ts
+++ b/src/telegram/normalize.ts
@@ -1,19 +1,53 @@
 import type { InboundMessage } from "../shared/types.js";
 
-export interface TelegramTextUpdate {
-  fromId: number;
-  chatId: number;
-  text: string;
+export interface TelegramUser {
+  id: number;
 }
 
-export function normalizeTelegramUpdate(update: TelegramTextUpdate): InboundMessage {
+export interface TelegramChat {
+  id: number;
+  type: string;
+}
+
+export interface TelegramMessage {
+  message_id?: number;
+  from?: TelegramUser;
+  chat?: TelegramChat;
+  text?: string;
+}
+
+export interface TelegramUpdate {
+  message?: TelegramMessage;
+}
+
+export function normalizeTelegramUpdate(update: TelegramUpdate): InboundMessage | null {
+  const message = update.message;
+
+  if (!message) {
+    return null;
+  }
+
+  if (message.chat?.type !== "private") {
+    return null;
+  }
+
+  if (typeof message.text !== "string") {
+    return null;
+  }
+
+  const chatId = message.chat.id;
+  const senderId = message.from?.id;
+
+  if (!Number.isInteger(chatId) || !Number.isInteger(senderId)) {
+    return null;
+  }
+
   return {
     channel: "telegram",
     accountId: "default",
     chatType: "direct",
-    conversationId: String(update.chatId),
-    senderId: String(update.fromId),
-    text: update.text
+    conversationId: String(chatId),
+    senderId: String(senderId),
+    text: message.text
   };
 }
-

--- a/test/telegram-normalize.test.ts
+++ b/test/telegram-normalize.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTelegramUpdate } from "../src/telegram/normalize.js";
+
+describe("normalizeTelegramUpdate", () => {
+  it("normalizes a Telegram private text message into an inbound message", () => {
+    expect(
+      normalizeTelegramUpdate({
+        message: {
+          from: { id: 42 },
+          chat: { id: 42, type: "private" },
+          text: "hello from telegram"
+        }
+      })
+    ).toEqual({
+      channel: "telegram",
+      accountId: "default",
+      chatType: "direct",
+      conversationId: "42",
+      senderId: "42",
+      text: "hello from telegram"
+    });
+  });
+
+  it("ignores non-private chats", () => {
+    expect(
+      normalizeTelegramUpdate({
+        message: {
+          from: { id: 42 },
+          chat: { id: -100123, type: "group" },
+          text: "hello group"
+        }
+      })
+    ).toBeNull();
+  });
+
+  it("ignores non-text messages", () => {
+    expect(
+      normalizeTelegramUpdate({
+        message: {
+          from: { id: 42 },
+          chat: { id: 42, type: "private" }
+        }
+      })
+    ).toBeNull();
+  });
+
+  it("ignores malformed messages without sender or valid ids", () => {
+    expect(
+      normalizeTelegramUpdate({
+        message: {
+          chat: { id: 42, type: "private" },
+          text: "missing sender"
+        }
+      })
+    ).toBeNull();
+
+    expect(
+      normalizeTelegramUpdate({
+        message: {
+          from: { id: 42 },
+          chat: { id: Number.NaN, type: "private" },
+          text: "bad chat id"
+        }
+      })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- Implement Task T13: accept Telegram private text messages and convert them to the internal `InboundMessage` shape required by Phase 1. 

### Description
- Add `src/telegram/normalize.ts` with `normalizeTelegramUpdate(update)` that accepts a Telegram-style update, validates `message`, ensures `chat.type === "private"`, requires textual `text`, validates integer `chat.id` and `from.id`, and returns `InboundMessage | null` accordingly. 
- Add unit tests in `test/telegram-normalize.test.ts` covering normalization of private text messages and ignoring non-private, non-text, or malformed updates. 
- Align `pnpm-lock.yaml` dependency specifier for `@anthropic-ai/claude-agent-sdk` with `package.json` to avoid lockfile/spec mismatch. 

### Testing
- Ran `source ~/.nvm/nvm.sh && nvm use && pnpm test`, and the Vitest suite passed (all tests passed). 
- Ran `source ~/.nvm/nvm.sh && nvm use && pnpm build`, and TypeScript compilation via `tsc` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf8729280c832ab28caa01e2c7f9ba)