### PR TITLE
Implement Telegram send support

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -1,8 +1,75 @@
+import { Api } from "grammy";
 import type { DeliveryTarget } from "../shared/types.js";
 
-export async function sendTelegramText(target: DeliveryTarget, text: string): Promise<void> {
-  void target;
-  void text;
-  await Promise.resolve();
+export interface TelegramTextApi {
+  sendMessage(chatId: number | string, text: string): Promise<unknown>;
 }
 
+export class TelegramSendError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = "TelegramSendError";
+  }
+}
+
+export function createTelegramTextSender(api: TelegramTextApi) {
+  return {
+    async sendText(target: DeliveryTarget, text: string): Promise<void> {
+      validateTarget(target);
+      validateText(text);
+
+      try {
+        await api.sendMessage(target.conversationId, text);
+      } catch (error) {
+        throw new TelegramSendError(
+          `Failed to send Telegram DM to conversation ${target.conversationId}: ${formatError(error)}`,
+          error
+        );
+      }
+    }
+  };
+}
+
+export async function sendTelegramText(
+  target: DeliveryTarget,
+  text: string,
+  api: TelegramTextApi
+): Promise<void> {
+  await createTelegramTextSender(api).sendText(target, text);
+}
+
+export function createTelegramApi(token: string): TelegramTextApi {
+  return new Api(token);
+}
+
+function validateTarget(target: DeliveryTarget): void {
+  if (target.channel !== "telegram") {
+    throw new TelegramSendError(`Unsupported delivery channel: ${target.channel}`);
+  }
+
+  if (target.accountId !== "default") {
+    throw new TelegramSendError(`Unsupported Telegram account: ${target.accountId}`);
+  }
+
+  if (target.chatType !== "direct") {
+    throw new TelegramSendError(`Unsupported Telegram chat type: ${target.chatType}`);
+  }
+
+  if (target.conversationId.trim().length === 0) {
+    throw new TelegramSendError("Telegram conversationId must not be empty");
+  }
+}
+
+function validateText(text: string): void {
+  if (text.length === 0) {
+    throw new TelegramSendError("Telegram text message must not be empty");
+  }
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/test/telegram-send.test.ts
+++ b/test/telegram-send.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  TelegramSendError,
+  createTelegramApi,
+  createTelegramTextSender,
+  sendTelegramText
+} from "../src/telegram/send.js";
+import type { DeliveryTarget } from "../src/shared/types.js";
+
+const directTarget: DeliveryTarget = {
+  channel: "telegram",
+  accountId: "default",
+  chatType: "direct",
+  conversationId: "123456"
+};
+
+describe("createTelegramTextSender", () => {
+  it("sends a text message to the target conversation id", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ ok: true });
+
+    await sendTelegramText(directTarget, "hello from baliclaw", { sendMessage });
+
+    expect(sendMessage).toHaveBeenCalledWith("123456", "hello from baliclaw");
+  });
+
+  it("rejects unsupported targets before calling the Telegram API", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ ok: true });
+    const sender = createTelegramTextSender({ sendMessage });
+
+    await expect(
+      sender.sendText({ ...directTarget, conversationId: "   " }, "hello")
+    ).rejects.toThrowError(new TelegramSendError("Telegram conversationId must not be empty"));
+
+    await expect(
+      sender.sendText({ ...directTarget, chatType: "group" as never }, "hello")
+    ).rejects.toThrowError(new TelegramSendError("Unsupported Telegram chat type: group"));
+
+    await expect(sender.sendText(directTarget, "")).rejects.toThrowError(
+      new TelegramSendError("Telegram text message must not be empty")
+    );
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns a diagnostic error when the Telegram API fails", async () => {
+    const sender = createTelegramTextSender({
+      sendMessage: vi.fn().mockRejectedValue(new Error("chat not found"))
+    });
+
+    await expect(sender.sendText(directTarget, "hello")).rejects.toMatchObject({
+      name: "TelegramSendError",
+      message: "Failed to send Telegram DM to conversation 123456: chat not found"
+    });
+  });
+});
+
+describe("createTelegramApi", () => {
+  it("creates a grammy Api instance", () => {
+    const api = createTelegramApi("123:abc");
+
+    expect(api).toHaveProperty("sendMessage");
+  });
+});


### PR DESCRIPTION
### Motivation
- Add Phase‑1 outbound Telegram capability (T14 / tech‑spec §9.4) so the daemon can send DM text replies addressed by `conversationId`.

### Description
- Add `src/telegram/send.ts` implementing `TelegramTextApi`, `createTelegramTextSender`, `sendTelegramText`, `createTelegramApi` and `TelegramSendError`, with explicit validation of `channel/accountId/chatType/conversationId` and text content.
- Errors from the Telegram API are wrapped into `TelegramSendError` with a diagnostic message including the target `conversationId`.
- The implementation uses `grammy`'s `Api` as the concrete API adapter but accepts a `TelegramTextApi` interface for easier testing and isolation.
- Add unit tests `test/telegram-send.test.ts` covering success, target/text validation, and API failure cases.

### Testing
- Ran the unit test suite with `pnpm test -- --runInBand`, and all tests passed (`Test Files 12 passed`, `Tests 41 passed`).
- Built the project with `pnpm build`, and TypeScript compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf984b38f4832ab539ba684554ebbe)