### PR TITLE
Implement TelegramService (T15) with grammy polling and tests

### DIFF
--- a/src/telegram/service.ts
+++ b/src/telegram/service.ts
@@ -1,9 +1,123 @@
+import { Bot, GrammyError, HttpError } from "grammy";
+import type { Logger } from "pino";
+import { getLogger } from "../shared/logger.js";
+import type { InboundMessage } from "../shared/types.js";
+import {
+  normalizeTelegramUpdate,
+  type TelegramUpdate
+} from "./normalize.js";
+
+export interface TelegramServiceContext {
+  update: TelegramUpdate;
+}
+
+export interface TelegramPollingBot {
+  on(filter: "message", handler: (context: TelegramServiceContext) => MaybePromise<unknown>): void;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+export interface TelegramServiceOptions {
+  token?: string;
+  bot?: TelegramPollingBot;
+  enqueueInbound?: (message: InboundMessage) => MaybePromise<unknown>;
+  logger?: Logger;
+}
+
+type MaybePromise<T> = T | Promise<T>;
+
 export class TelegramService {
+  private bot: TelegramPollingBot | undefined;
+  private readonly token: string;
+  private readonly enqueueInbound: (message: InboundMessage) => MaybePromise<unknown>;
+  private readonly logger: Logger;
+  private started = false;
+
+  constructor(options: TelegramServiceOptions = {}) {
+    this.bot = options.bot;
+    this.token = options.token ?? "";
+    this.enqueueInbound = options.enqueueInbound ?? (() => undefined);
+    this.logger = options.logger ?? getLogger("telegram");
+
+    if (this.bot) {
+      this.registerMessageHandler(this.bot);
+    }
+  }
+
+  private registerMessageHandler(bot: TelegramPollingBot): void {
+    bot.on("message", (context) => {
+      const inbound = normalizeTelegramUpdate(context.update);
+
+      if (!inbound) {
+        return;
+      }
+
+      void Promise.resolve(this.enqueueInbound(inbound)).catch((error: unknown) => {
+        this.logger.error(
+          {
+            err: error,
+            senderId: inbound.senderId,
+            conversationId: inbound.conversationId
+          },
+          "failed to enqueue telegram message"
+        );
+      });
+    });
+  }
+
   async start(): Promise<void> {
-    await Promise.resolve();
+    if (this.started) {
+      return;
+    }
+
+    try {
+      const bot = this.bot ?? createTelegramBot(this.token);
+
+      if (!this.bot) {
+        this.bot = bot;
+        this.registerMessageHandler(bot);
+      }
+
+      await bot.start();
+      this.started = true;
+      this.logger.info("telegram polling started");
+    } catch (error) {
+      this.logger.error({ err: error }, "failed to start telegram polling");
+      throw toTelegramServiceError(error);
+    }
   }
 
   async stop(): Promise<void> {
-    await Promise.resolve();
+    if (!this.started) {
+      return;
+    }
+
+    await this.bot?.stop();
+    this.started = false;
+    this.logger.info("telegram polling stopped");
   }
+}
+
+export function createTelegramBot(token: string): TelegramPollingBot {
+  return new Bot(token);
+}
+
+function toTelegramServiceError(error: unknown): Error {
+  if (error instanceof GrammyError) {
+    return new Error(`Telegram API error ${error.error_code}: ${error.description}`, {
+      cause: error
+    });
+  }
+
+  if (error instanceof HttpError) {
+    return new Error(`Telegram network error: ${error.message}`, {
+      cause: error
+    });
+  }
+
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(`Unknown Telegram error: ${String(error)}`);
 }

--- a/test/telegram-service.test.ts
+++ b/test/telegram-service.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import { TelegramService } from "../src/telegram/service.js";
+import { createLogger } from "../src/shared/logger.js";
+
+interface RegisteredHandler {
+  (context: { update: unknown }): unknown;
+}
+
+class FakeTelegramBot {
+  handler: RegisteredHandler | undefined;
+  start = vi.fn(async () => undefined);
+  stop = vi.fn(async () => undefined);
+
+  on(_filter: "message", handler: RegisteredHandler): void {
+    this.handler = handler;
+  }
+}
+
+describe("TelegramService", () => {
+  it("starts and stops grammy polling only once", async () => {
+    const bot = new FakeTelegramBot();
+    const service = new TelegramService({ bot, token: "unused" });
+
+    await service.start();
+    await service.start();
+    await service.stop();
+    await service.stop();
+
+    expect(bot.start).toHaveBeenCalledTimes(1);
+    expect(bot.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("enqueues only private text messages", async () => {
+    const bot = new FakeTelegramBot();
+    const enqueueInbound = vi.fn();
+    const service = new TelegramService({ bot, enqueueInbound });
+
+    expect(service).toBeDefined();
+    expect(bot.handler).toBeTypeOf("function");
+
+    bot.handler?.({
+      update: {
+        message: {
+          from: { id: 42 },
+          chat: { id: 42, type: "private" },
+          text: "hello"
+        }
+      }
+    });
+
+    bot.handler?.({
+      update: {
+        message: {
+          from: { id: 42 },
+          chat: { id: -100, type: "group" },
+          text: "ignored"
+        }
+      }
+    });
+
+    bot.handler?.({
+      update: {
+        message: {
+          from: { id: 42 },
+          chat: { id: 42, type: "private" }
+        }
+      }
+    });
+
+    expect(enqueueInbound).toHaveBeenCalledTimes(1);
+    expect(enqueueInbound).toHaveBeenCalledWith({
+      channel: "telegram",
+      accountId: "default",
+      chatType: "direct",
+      conversationId: "42",
+      senderId: "42",
+      text: "hello"
+    });
+  });
+
+  it("returns from the handler immediately after queueing work", async () => {
+    const bot = new FakeTelegramBot();
+    let resolveEnqueue: (() => void) | undefined;
+    const enqueueInbound = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveEnqueue = resolve;
+        })
+    );
+
+    new TelegramService({ bot, enqueueInbound });
+
+    const started = performance.now();
+    const result = bot.handler?.({
+      update: {
+        message: {
+          from: { id: 7 },
+          chat: { id: 7, type: "private" },
+          text: "slow turn"
+        }
+      }
+    });
+    const elapsed = performance.now() - started;
+
+    expect(result).toBeUndefined();
+    expect(elapsed).toBeLessThan(50);
+    expect(enqueueInbound).toHaveBeenCalledTimes(1);
+
+    resolveEnqueue?.();
+  });
+
+  it("logs enqueue failures without throwing from the handler", async () => {
+    const bot = new FakeTelegramBot();
+    const destination = { write: vi.fn(() => true) };
+    const logger = createLogger({ subsystem: "telegram", destination });
+    const enqueueInbound = vi.fn().mockRejectedValue(new Error("queue full"));
+
+    new TelegramService({ bot, enqueueInbound, logger });
+
+    expect(() =>
+      bot.handler?.({
+        update: {
+          message: {
+            from: { id: 9 },
+            chat: { id: 9, type: "private" },
+            text: "hello"
+          }
+        }
+      })
+    ).not.toThrow();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(destination.write).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a real Telegram long-polling service per T15 so daemon can receive private DM updates and asynchronously hand them to the daemon processing pipeline. 

### Description

- Added a concrete `TelegramService` implementation that wraps `grammy` long-polling with idempotent `start()`/`stop()` semantics and converts updates using the existing `normalizeTelegramUpdate` logic in `src/telegram/service.ts`. 
- The service accepts injected `bot`, `token`, `enqueueInbound` and `logger` options so tests and daemon wiring can supply mocks, and the handler only performs lightweight validation and async enqueueing (it does not await agent execution). 
- Errors from enqueueing are logged with `senderId` and `conversationId` and translated to a diagnostic error on `start()` failures, preserving the non-blocking handler requirement. 
- Added unit tests `test/telegram-service.test.ts` covering polling lifecycle idempotency, private-text filtering, immediate handler return, and enqueue-failure logging behavior.

### Testing

- Ran the test suite with `pnpm test` and all tests passed: `Test Files  13 passed (13)` and `Tests  45 passed (45)`.
- Built the project with `pnpm build` and TypeScript compilation succeeded with `tsc -p tsconfig.json`.
- The new test file `test/telegram-service.test.ts` executed as part of the suite and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9cd46898832ab5c21a2a3f523e37)