### PR TITLE
Implement pairing store (pending + allowlist persistence)

### DIFF
--- a/src/auth/pairing-store.ts
+++ b/src/auth/pairing-store.ts
@@ -1,18 +1,50 @@
 import { readJson5FileOrDefault, writeJson5File } from "../config/file-store.js";
-import { getAppPaths } from "../config/paths.js";
+import { getAppPaths, type AppPaths } from "../config/paths.js";
+import type { PairingRequest } from "../shared/types.js";
 
 export interface PairingStoreData {
   approvedSenderIds: string[];
 }
 
+export interface PendingPairingStoreData {
+  requests: PairingRequest[];
+}
+
+const defaultAllowlistData = (): PairingStoreData => ({
+  approvedSenderIds: []
+});
+
+const defaultPendingData = (): PendingPairingStoreData => ({
+  requests: []
+});
+
 export class PairingStore {
-  private readonly file = getAppPaths().allowlistFile;
+  constructor(private readonly paths: AppPaths = getAppPaths()) {}
 
   async load(): Promise<PairingStoreData> {
-    return readJson5FileOrDefault<PairingStoreData>(this.file, { approvedSenderIds: [] });
+    return this.loadAllowlist();
   }
 
   async save(data: PairingStoreData): Promise<void> {
-    await writeJson5File(this.file, data);
+    await this.saveAllowlist(data);
+  }
+
+  async loadAllowlist(): Promise<PairingStoreData> {
+    return readJson5FileOrDefault<PairingStoreData>(this.paths.allowlistFile, defaultAllowlistData());
+  }
+
+  async saveAllowlist(data: PairingStoreData): Promise<void> {
+    await writeJson5File(this.paths.allowlistFile, data);
+  }
+
+  async loadPendingRequests(): Promise<PendingPairingStoreData> {
+    return readJson5FileOrDefault<PendingPairingStoreData>(
+      this.paths.pendingPairingFile,
+      defaultPendingData()
+    );
+  }
+
+  async savePendingRequests(data: PendingPairingStoreData): Promise<void> {
+    await writeJson5File(this.paths.pendingPairingFile, data);
   }
 }

--- a/test/pairing-store.test.ts
+++ b/test/pairing-store.test.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PairingStore } from "../src/auth/pairing-store.js";
+import { getAppPaths } from "../src/config/paths.js";
+
+describe("PairingStore", () => {
+  it("returns default pending requests and allowlist when files are missing", async () => {
+    const home = await mkdtemp(join(tmpdir(), "baliclaw-pairing-defaults-"));
+    const store = new PairingStore(getAppPaths(home));
+
+    try {
+      await expect(store.loadPendingRequests()).resolves.toEqual({
+        requests: []
+      });
+      await expect(store.loadAllowlist()).resolves.toEqual({
+        approvedSenderIds: []
+      });
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("persists pending requests and approved sender ids in separate files", async () => {
+    const home = await mkdtemp(join(tmpdir(), "baliclaw-pairing-persist-"));
+    const paths = getAppPaths(home);
+    const store = new PairingStore(paths);
+
+    try {
+      await store.savePendingRequests({
+        requests: [
+          {
+            code: "ABCD2345",
+            senderId: "12345",
+            username: "alice",
+            createdAt: "2026-03-22T10:00:00.000Z",
+            expiresAt: "2026-03-22T11:00:00.000Z"
+          }
+        ]
+      });
+      await store.saveAllowlist({
+        approvedSenderIds: ["12345", "67890"]
+      });
+
+      await expect(store.loadPendingRequests()).resolves.toEqual({
+        requests: [
+          {
+            code: "ABCD2345",
+            senderId: "12345",
+            username: "alice",
+            createdAt: "2026-03-22T10:00:00.000Z",
+            expiresAt: "2026-03-22T11:00:00.000Z"
+          }
+        ]
+      });
+      await expect(store.loadAllowlist()).resolves.toEqual({
+        approvedSenderIds: ["12345", "67890"]
+      });
+
+      await expect(readFile(paths.pendingPairingFile, "utf8")).resolves.toContain("'ABCD2345'");
+      await expect(readFile(paths.allowlistFile, "utf8")).resolves.toContain("'67890'");
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("rewrites store files atomically without leaving temp files behind", async () => {
+    const home = await mkdtemp(join(tmpdir(), "baliclaw-pairing-atomic-"));
+    const paths = getAppPaths(home);
+    const store = new PairingStore(paths);
+
+    try {
+      await store.savePendingRequests({
+        requests: [
+          {
+            code: "FIRST111",
+            senderId: "111",
+            createdAt: "2026-03-22T10:00:00.000Z",
+            expiresAt: "2026-03-22T11:00:00.000Z"
+          }
+        ]
+      });
+      await store.savePendingRequests({
+        requests: [
+          {
+            code: "SECOND22",
+            senderId: "222",
+            createdAt: "2026-03-22T12:00:00.000Z",
+            expiresAt: "2026-03-22T13:00:00.000Z"
+          }
+        ]
+      });
+      await store.saveAllowlist({
+        approvedSenderIds: ["222"]
+      });
+      await store.saveAllowlist({
+        approvedSenderIds: ["333"]
+      });
+
+      await expect(readFile(paths.pendingPairingFile, "utf8")).resolves.toContain("'SECOND22'");
+      await expect(readFile(paths.allowlistFile, "utf8")).resolves.toContain("'333'");
+      await expect(readdir(paths.pairingDir).then((entries) => entries.sort())).resolves.toEqual([
+        "telegram-allowlist.json",
+        "telegram-pending.json"
+      ]);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Fulfill T16 by providing persistent storage for Telegram pending pairing requests and the allowlist as described in `tech-spec.md` sections 10.2 and 10.5.

### Description

- Add `PairingStore` API to read/write allowlist and pending requests separately, preserving existing `load`/`save` as allowlist-compatible methods in `src/auth/pairing-store.ts`.
- Introduce `PendingPairingStoreData` and use the shared `PairingRequest` type to model pending requests, and add default-value helpers for missing files.
- Back the files with JSON5 + atomic writes via the existing `writeJson5File`/`readJson5FileOrDefault` utilities so writes are atomic and human-inspectable; files are `telegram-pending.json` and `telegram-allowlist.json` as per `getAppPaths()`.
- Add unit tests in `test/pairing-store.test.ts` covering default reads, persistence to separate files, and atomic rewrite behavior.

### Testing

- Ran the Vitest suite with `pnpm test`, which executed the new `test/pairing-store.test.ts` and the full test suite; all tests passed (`48 passed`).
- Built TypeScript with `pnpm build` to ensure compilation succeeded; the build completed without errors.
- The added unit tests verify reading defaults when files are missing, correct file contents after saves, and atomic rewrites (no leftover temp files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa5ab74a0832a88639edddd6b6c70)