### PR TITLE
feat(cli): add local TUI command for interactive debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ node dist/cli/index.js config get
 node dist/cli/index.js config set --path channels.telegram.botToken '<TOKEN>'
 node dist/cli/index.js pairing list telegram
 node dist/cli/index.js pairing approve telegram <CODE>
+node dist/cli/index.js tui
 ```
 
 Current CLI command groups:
@@ -167,6 +168,7 @@ Current CLI command groups:
 - `pairing list telegram`
 - `pairing approve telegram <CODE>`
 - `daemon start`
+- `tui`
 
 ## Configuration
 

--- a/src/cli/commands/tui.ts
+++ b/src/cli/commands/tui.ts
@@ -1,0 +1,179 @@
+import { createInterface, type Interface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import type { AppConfig } from "../../config/schema.js";
+import { ConfigService } from "../../config/service.js";
+import { AgentService } from "../../runtime/agent-service.js";
+import type { AgentRunOptions } from "../../runtime/agent-service.js";
+import type { InboundMessage } from "../../shared/types.js";
+
+const localChannel = "telegram" as const;
+const localAccount = "default" as const;
+const localChatType = "direct" as const;
+const localSenderId = "local-operator";
+const localConversationId = "local-tui";
+
+const helpText = [
+  "Commands:",
+  "  /help  Show this help.",
+  "  /new   Start a fresh Claude session.",
+  "  /exit  Quit the TUI.",
+  "  /quit  Quit the TUI."
+].join("\n");
+
+export type TuiControlCommand = "help" | "new" | "exit" | "quit";
+
+export interface TuiCommandDependencies {
+  configService?: Pick<ConfigService, "load">;
+  agentService?: Pick<AgentService, "handleMessage">;
+  createSessionId?: () => string;
+  now?: () => Date;
+  createReadline?: () => Interface;
+  writeLine?: (line: string) => void;
+}
+
+export interface ParsedTuiInput {
+  prompt?: string;
+  command?: TuiControlCommand;
+}
+
+export async function runTuiCommand(dependencies: TuiCommandDependencies = {}): Promise<string> {
+  const configService = dependencies.configService ?? new ConfigService();
+  const agentService = dependencies.agentService ?? new AgentService();
+  const writeLine = dependencies.writeLine ?? ((line: string) => stdout.write(`${line}\n`));
+
+  const config = await configService.load();
+  let sessionId = (dependencies.createSessionId ?? (() => createTuiSessionId(dependencies.now?.())) )();
+
+  writeLine("BaliClaw local TUI started.");
+  writeLine("Type your prompt, or use /help for commands.");
+
+  const readline =
+    dependencies.createReadline?.() ??
+    createInterface({
+      input: stdin,
+      output: stdout
+    });
+
+  try {
+    while (true) {
+      const raw = await readline.question("you> ");
+      const input = parseTuiInput(raw);
+
+      if (input.command) {
+        if (input.command === "help") {
+          writeLine(helpText);
+          continue;
+        }
+
+        if (input.command === "new") {
+          sessionId = (dependencies.createSessionId ?? (() => createTuiSessionId(dependencies.now?.())) )();
+          writeLine("Started a fresh local session.");
+          continue;
+        }
+
+        if (input.command === "exit" || input.command === "quit") {
+          writeLine("Bye.");
+          break;
+        }
+      }
+
+      if (!input.prompt) {
+        continue;
+      }
+
+      const reply = await agentService.handleMessage(
+        {
+          channel: localChannel,
+          accountId: localAccount,
+          chatType: localChatType,
+          conversationId: localConversationId,
+          senderId: localSenderId,
+          text: input.prompt
+        },
+        buildTuiAgentRunOptions(config, sessionId)
+      );
+
+      writeLine(`assistant> ${reply}`);
+    }
+  } finally {
+    readline.close();
+  }
+
+  return "TUI closed.";
+}
+
+export function parseTuiInput(raw: string): ParsedTuiInput {
+  const text = raw.trim();
+  if (!text) {
+    return {};
+  }
+
+  if (text === "/help") {
+    return { command: "help" };
+  }
+  if (text === "/new") {
+    return { command: "new" };
+  }
+  if (text === "/exit") {
+    return { command: "exit" };
+  }
+  if (text === "/quit") {
+    return { command: "quit" };
+  }
+
+  return { prompt: text };
+}
+
+export function buildTuiAgentRunOptions(config: AppConfig, sessionId: string): AgentRunOptions {
+  const options: AgentRunOptions = {
+    cwd: config.runtime.workingDirectory,
+    sessionId,
+    loadFilesystemSettings: config.runtime.loadFilesystemSettings,
+    tools: config.tools.availableTools,
+    memoryEnabled: config.memory.enabled,
+    memoryMaxLines: config.memory.maxLines
+  };
+
+  if (config.runtime.model) {
+    options.model = config.runtime.model;
+  }
+  if (config.runtime.maxTurns !== undefined) {
+    options.maxTurns = config.runtime.maxTurns;
+  }
+  if (config.runtime.systemPromptFile) {
+    options.systemPromptFile = config.runtime.systemPromptFile;
+  }
+  if (config.runtime.soulFile) {
+    options.soulFile = config.runtime.soulFile;
+  }
+  if (config.runtime.userFile) {
+    options.userFile = config.runtime.userFile;
+  }
+
+  if (config.skills.enabled) {
+    options.skillDirectories = config.skills.directories;
+  }
+  if (Object.keys(config.mcp.servers).length > 0) {
+    options.mcpServers = config.mcp.servers;
+  }
+  if (Object.keys(config.agents).length > 0) {
+    options.agents = config.agents;
+  }
+
+  return options;
+}
+
+export function createLocalTuiMessage(prompt: string): InboundMessage {
+  return {
+    channel: localChannel,
+    accountId: localAccount,
+    chatType: localChatType,
+    conversationId: localConversationId,
+    senderId: localSenderId,
+    text: prompt
+  };
+}
+
+export function createTuiSessionId(now: Date = new Date()): string {
+  return `tui-${now.toISOString()}-${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { runConfigGetCommand, runConfigSetCommand } from "./commands/config.js";
 import { runDaemonCommand } from "./commands/daemon.js";
 import { runPairingApproveCommand, runPairingListCommand } from "./commands/pairing.js";
 import { runStatusCommand } from "./commands/status.js";
+import { runTuiCommand } from "./commands/tui.js";
 
 const program = new Command();
 
@@ -18,6 +19,14 @@ program
   .description("Show daemon status")
   .action(async () => {
     console.log(await runStatusCommand());
+  });
+
+
+program
+  .command("tui")
+  .description("Run a local terminal chat interface")
+  .action(async () => {
+    await runTuiCommand();
   });
 
 const configCommand = program

--- a/test/tui-command.test.ts
+++ b/test/tui-command.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { buildTuiAgentRunOptions, parseTuiInput } from "../src/cli/commands/tui.js";
+import type { AppConfig } from "../src/config/schema.js";
+
+const baseConfig: AppConfig = {
+  channels: {
+    telegram: {
+      enabled: false,
+      botToken: ""
+    }
+  },
+  runtime: {
+    workingDirectory: "/tmp/baliclaw-workdir",
+    model: "claude-sonnet-4-5",
+    maxTurns: 8,
+    loadFilesystemSettings: true
+  },
+  tools: {
+    availableTools: ["Read", "Write"]
+  },
+  skills: {
+    enabled: true,
+    directories: ["/tmp/skills"]
+  },
+  logging: {
+    level: "info"
+  },
+  mcp: {
+    servers: {
+      docs: {
+        type: "http",
+        url: "https://example.com/mcp",
+        headers: {
+          Authorization: "Bearer token"
+        }
+      }
+    }
+  },
+  agents: {
+    helper: {
+      description: "Helper agent",
+      prompt: "assist"
+    }
+  },
+  memory: {
+    enabled: true,
+    globalEnabled: false,
+    maxLines: 300
+  }
+};
+
+describe("TUI command helpers", () => {
+  it("parses TUI control commands", () => {
+    expect(parseTuiInput("/help")).toEqual({ command: "help" });
+    expect(parseTuiInput(" /new ")).toEqual({ command: "new" });
+    expect(parseTuiInput("/exit")).toEqual({ command: "exit" });
+    expect(parseTuiInput("/quit")).toEqual({ command: "quit" });
+  });
+
+  it("parses normal prompt input", () => {
+    expect(parseTuiInput("  tell me a joke ")).toEqual({ prompt: "tell me a joke" });
+    expect(parseTuiInput("   ")).toEqual({});
+  });
+
+  it("builds agent options from runtime config", () => {
+    const options = buildTuiAgentRunOptions(baseConfig, "tui-session-1");
+
+    expect(options).toEqual({
+      cwd: "/tmp/baliclaw-workdir",
+      sessionId: "tui-session-1",
+      model: "claude-sonnet-4-5",
+      maxTurns: 8,
+      loadFilesystemSettings: true,
+      tools: ["Read", "Write"],
+      skillDirectories: ["/tmp/skills"],
+      mcpServers: {
+        docs: {
+          type: "http",
+          url: "https://example.com/mcp",
+          headers: {
+            Authorization: "Bearer token"
+          }
+        }
+      },
+      agents: {
+        helper: {
+          description: "Helper agent",
+          prompt: "assist"
+        }
+      },
+      memoryEnabled: true,
+      memoryMaxLines: 300
+    });
+  });
+
+  it("does not pass skill directories when skills are disabled", () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      skills: {
+        enabled: false,
+        directories: ["/tmp/ignored"]
+      }
+    };
+
+    const options = buildTuiAgentRunOptions(config, "tui-session-2");
+    expect(options.skillDirectories).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a lightweight local interaction surface so operators and developers can debug BaliClaw without configuring Telegram or other channels. 

### Description

- Add a new `baliclaw tui` CLI command and wire it into the main CLI entrypoint via `src/cli/index.ts`. 
- Implement `runTuiCommand` in `src/cli/commands/tui.ts`, a `readline`-based terminal loop that accepts prompts and supports control commands `/help`, `/new`, `/exit`, and `/quit`. 
- Map runtime config values into `AgentService` invocation options so TUI behavior mirrors configured runtime (working directory, model, tools, skills, MCP servers, agents, and memory). 
- Add unit tests in `test/tui-command.test.ts` for input parsing and config-to-agent options mapping, and update `README.md` to document the new command. 

### Testing

- Ran `pnpm build` which completed successfully. 
- Ran the focused unit tests with `pnpm exec vitest run test/tui-command.test.ts` and the new TUI tests passed. 
- Note: a full `pnpm test` run in this environment showed unrelated pre-existing failures in `test/sdk.test.ts`; these failures are external to the TUI changes while the targeted TUI tests are green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e2973c0c832a81cf677a4fc433f3)