### PR TITLE
feat: preinstall find-skills and skill-creator starter skills

### DIFF
--- a/src/config/workspace.ts
+++ b/src/config/workspace.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { AppPaths } from "./paths.js";
 
@@ -228,13 +228,24 @@ export function getDefaultWorkspaceDirectory(paths: AppPaths): string {
 
 export async function ensureWorkspaceScaffold(workingDirectory: string): Promise<void> {
   await mkdir(workingDirectory, { recursive: true });
+  const findSkillsDirectory = join(workingDirectory, ".claude", "skills", "find-skills");
+  const skillCreatorDirectory = join(workingDirectory, ".claude", "skills", "skill-creator");
+
   await Promise.all([
     writeDefaultFile(join(workingDirectory, "AGENTS.md"), defaultAgentsFileContents),
     writeDefaultFile(join(workingDirectory, "SOUL.md"), defaultSoulFileContents),
     writeDefaultFile(join(workingDirectory, "USER.md"), defaultUserFileContents),
-    writeDefaultFile(join(workingDirectory, ".claude", "skills", "find-skills", "SKILL.md"), defaultFindSkillsFileContents),
-    writeDefaultFile(join(workingDirectory, ".claude", "skills", "skill-creator", "SKILL.md"), defaultSkillCreatorFileContents)
+    writeDefaultSkill(findSkillsDirectory, defaultFindSkillsFileContents),
+    writeDefaultSkill(skillCreatorDirectory, defaultSkillCreatorFileContents)
   ]);
+}
+
+async function writeDefaultSkill(skillDirectory: string, contents: string): Promise<void> {
+  if (await directoryExists(skillDirectory)) {
+    return;
+  }
+
+  await writeDefaultFile(join(skillDirectory, "SKILL.md"), contents);
 }
 
 async function writeDefaultFile(path: string, contents: string): Promise<void> {
@@ -251,6 +262,23 @@ async function writeDefaultFile(path: string, contents: string): Promise<void> {
   }
 }
 
+async function directoryExists(path: string): Promise<boolean> {
+  try {
+    const result = await stat(path);
+    return result.isDirectory();
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
 function isExistingFileError(error: unknown): error is NodeJS.ErrnoException {
   return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+}
+
+function isMissingPathError(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 }

--- a/test/config-service.test.ts
+++ b/test/config-service.test.ts
@@ -79,6 +79,27 @@ describe("ConfigService", () => {
     }
   });
 
+  it("does not overwrite pre-existing starter skill directories", async () => {
+    const home = await mkdtemp(join(tmpdir(), "baliclaw-config-existing-skill-"));
+    const workspaceDirectory = join(home, ".baliclaw", "workspace");
+    const existingSkillDirectory = join(workspaceDirectory, ".claude", "skills", "find-skills");
+    const existingSkillFile = join(existingSkillDirectory, "SKILL.md");
+
+    try {
+      await mkdir(existingSkillDirectory, { recursive: true });
+      await writeFile(existingSkillFile, "custom find-skills content\n", "utf8");
+
+      await new ConfigService(getAppPaths(home)).load();
+
+      await expect(readFile(existingSkillFile, "utf8")).resolves.toBe("custom find-skills content\n");
+      await expect(
+        readFile(join(workspaceDirectory, ".claude", "skills", "skill-creator", "SKILL.md"), "utf8")
+      ).resolves.toContain("name: skill-creator");
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("returns a structured error for unknown top-level fields", async () => {
     const home = await mkdtemp(join(tmpdir(), "baliclaw-config-unknown-"));
     const paths = getAppPaths(home);


### PR DESCRIPTION
### Motivation
- Provide useful starter SDK-native skills on first install so users can discover and extend capabilities without creating skills from scratch. 
- Ensure workspace scaffold creates nested `.claude/skills/*/SKILL.md` files so SDK skill discovery works out-of-the-box.

### Description
- Add two bundled skill templates `find-skills` and `skill-creator` as `defaultFindSkillsFileContents` and `defaultSkillCreatorFileContents` in `src/config/workspace.ts`.
- Extend `ensureWorkspaceScaffold()` to write `.claude/skills/find-skills/SKILL.md` and `.claude/skills/skill-creator/SKILL.md` during initial workspace scaffolding.
- Make `writeDefaultFile()` create parent directories with `mkdir(dirname(path), { recursive: true })` before attempting to write, preventing failures when nested folders do not exist.
- Update `test/config-service.test.ts` to assert that both starter `SKILL.md` files are present and contain the expected `name` entries after loading defaults.

### Testing
- Ran `pnpm vitest run test/config-service.test.ts` and the updated config-service tests passed. 
- Running the focused `pnpm test -- config-service.test.ts` confirmed the same targeted tests pass. 
- A full `pnpm test` run observed two existing failures in `test/sdk.test.ts` unrelated to these workspace scaffolding changes and not introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e6646398832aa58488f3cac566be)